### PR TITLE
Add support for TypeScript

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -24,6 +24,15 @@
         "test",
         "tool"
       ]
+    },
+    {
+      "login": "otofu-square",
+      "name": "otofu-square",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/10118235?v=4",
+      "profile": "https://github.com/otofu-square",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Simple component wrapper and utilities for testing React hooks.
 [![downloads](https://img.shields.io/npm/dm/react-hooks-testing-library.svg?style=flat-square)](http://www.npmtrends.com/react-hooks-testing-library)
 [![MIT License](https://img.shields.io/npm/l/react-hooks-testing-library.svg?style=flat-square)](https://github.com/mpeyper/react-hooks-testing-library/blob/master/LICENSE.md)
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 [![Code of Conduct](https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square)](https://github.com/mpeyper/react-hooks-testing-library/blob/master/CODE_OF_CONDUCT.md)
 
@@ -156,8 +156,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars0.githubusercontent.com/u/23029903?v=4" width="100px;"/><br /><sub><b>Michael Peyper</b></sub>](https://github.com/mpeyper)<br />[💻](https://github.com/mpeyper/react-hooks-testing-library/commits?author=mpeyper "Code") [🎨](#design-mpeyper "Design") [📖](https://github.com/mpeyper/react-hooks-testing-library/commits?author=mpeyper "Documentation") [🤔](#ideas-mpeyper "Ideas, Planning, & Feedback") [🚇](#infra-mpeyper "Infrastructure (Hosting, Build-Tools, etc)") [📦](#platform-mpeyper "Packaging/porting to new platform") [⚠️](https://github.com/mpeyper/react-hooks-testing-library/commits?author=mpeyper "Tests") [🔧](#tool-mpeyper "Tools") |
-| :---: |
+<table><tr><td align="center"><a href="https://github.com/mpeyper"><img src="https://avatars0.githubusercontent.com/u/23029903?v=4" width="100px;" alt="Michael Peyper"/><br /><sub><b>Michael Peyper</b></sub></a><br /><a href="https://github.com/mpeyper/react-hooks-testing-library/commits?author=mpeyper" title="Code">💻</a> <a href="#design-mpeyper" title="Design">🎨</a> <a href="https://github.com/mpeyper/react-hooks-testing-library/commits?author=mpeyper" title="Documentation">📖</a> <a href="#ideas-mpeyper" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-mpeyper" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#platform-mpeyper" title="Packaging/porting to new platform">📦</a> <a href="https://github.com/mpeyper/react-hooks-testing-library/commits?author=mpeyper" title="Tests">⚠️</a> <a href="#tool-mpeyper" title="Tools">🔧</a></td><td align="center"><a href="https://github.com/otofu-square"><img src="https://avatars0.githubusercontent.com/u/10118235?v=4" width="100px;" alt="otofu-square"/><br /><sub><b>otofu-square</b></sub></a><br /><a href="https://github.com/mpeyper/react-hooks-testing-library/commits?author=otofu-square" title="Code">💻</a></td></tr></table>
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,13 @@
 import { cleanup, act, RenderOptions, RenderResult } from 'react-testing-library'
 
-export function renderHook<P extends any, T extends (...args: [P]) => any>(
-  callback: (_: P) => ReturnType<T>,
+export function renderHook<P extends any, R extends any>(
+  callback: (...args: [P]) => R,
   options?: {
     initialProps?: P
   } & RenderOptions
 ): {
   readonly result: {
-    current: ReturnType<T>
+    current: R
   }
   readonly unmount: RenderResult['unmount']
   readonly rerender: (hookProps?: P) => void

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import { cleanup, act, RenderOptions, RenderResult } from 'react-testing-library'
 
-export function renderHook<P extends any, R extends any>(
+export function renderHook<P, R>(
   callback: (...args: [P]) => R,
   options?: {
     initialProps?: P

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 import { cleanup, act, RenderOptions, RenderResult } from 'react-testing-library'
 
-export function renderHook<T extends (...args: any[]) => any>(
-  callback: T,
+export function renderHook<P extends any, T extends (...args: [P]) => any>(
+  callback: (_: P) => ReturnType<T>,
   options?: {
-    initialProps?: Parameters<T>[0]
+    initialProps?: P
     options?: RenderOptions
   }
 ): {
@@ -11,7 +11,7 @@ export function renderHook<T extends (...args: any[]) => any>(
     current: ReturnType<T>
   }
   readonly unmount: RenderResult['unmount']
-  readonly rerender: (hookProps?: Parameters<T>[0]) => void
+  readonly rerender: (hookProps?: P) => void
 }
 
 export const testHook: typeof renderHook

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { cleanup, act, RenderOptions, RenderResult } from 'react-testing-library'
 
 export function renderHook<P, R>(
-  callback: (...args: [P]) => R,
+  callback: (props: P) => R,
   options?: {
     initialProps?: P
   } & RenderOptions

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,19 @@
+import { cleanup, act, RenderOptions, RenderResult } from 'react-testing-library'
+
+export function renderHook<T extends (...args: any[]) => any>(
+  callback: T,
+  options?: {
+    initialProps?: Parameters<T>[0]
+    options?: RenderOptions
+  }
+): {
+  readonly result: {
+    current: ReturnType<T>
+  }
+  readonly unmount: RenderResult['unmount']
+  readonly rerender: (hookProps?: Parameters<T>[0]) => void
+}
+
+export const testHook: typeof renderHook
+
+export { cleanup, act }

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,8 +4,7 @@ export function renderHook<P extends any, T extends (...args: [P]) => any>(
   callback: (_: P) => ReturnType<T>,
   options?: {
     initialProps?: P
-    options?: RenderOptions
-  }
+  } & RenderOptions
 ): {
   readonly result: {
     current: ReturnType<T>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1058,6 +1058,22 @@
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
       "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q=="
     },
+    "@types/prop-types": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.0.tgz",
+      "integrity": "sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.5.tgz",
+      "integrity": "sha512-8LRySaaSJVLNZb2dbOGvGmzn88cbAfrgDpuWy+6lLgQ0OJFgHHvyuaCX4/7ikqJlpmCPf4uazJAZcfTQRdJqdQ==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -2114,6 +2130,12 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csstype": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.2.tgz",
+      "integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow==",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -6349,6 +6371,12 @@
             "string-width": "^2.1.1"
           }
         },
+        "typescript": {
+          "version": "2.9.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+          "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+          "dev": true
+        },
         "write": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
@@ -8155,9 +8183,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
     },
     "typescript-eslint-parser": {
@@ -8176,6 +8204,15 @@
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         }
+      }
+    },
+    "typings-tester": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/typings-tester/-/typings-tester-0.3.2.tgz",
+      "integrity": "sha512-HjGoAM2UoGhmSKKy23TYEKkxlphdJFdix5VvqWFLzH1BJVnnwG38tpC6SXPgqhfFGfHY77RlN1K8ts0dbWBQ7A==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.12.2"
       }
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-react": "^7.0.0",
+    "@types/react": "^16.8.5",
     "all-contributors-cli": "^6.1.2",
     "babel-eslint": "^10.0.1",
     "babel-plugin-module-resolver": "^3.2.0",
@@ -39,7 +40,9 @@
     "prettier-eslint": "^8.8.2",
     "prettier-eslint-cli": "^4.7.1",
     "react": "^16.8.3",
-    "react-dom": "^16.8.3"
+    "react-dom": "^16.8.3",
+    "typescript": "^3.3.3333",
+    "typings-tester": "^0.3.2"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.4",
   "description": "Simple component wrapper for testing React hooks",
   "main": "lib/index.js",
+  "typings": "./index.d.ts",
   "author": "Michael Peyper",
   "repository": {
     "type": "git",

--- a/test/typescript.test.js
+++ b/test/typescript.test.js
@@ -1,0 +1,7 @@
+import { checkDirectory } from 'typings-tester'
+
+describe('TypeScript definitions', function() {
+  it('should compile against index.d.ts', () => {
+    checkDirectory(__dirname + '/typescript')
+  })
+})

--- a/test/typescript/renderHook.ts
+++ b/test/typescript/renderHook.ts
@@ -1,0 +1,60 @@
+import { useState, createContext, useContext, useMemo } from 'react'
+import { renderHook } from 'react-hooks-testing-library'
+
+const DARK: 'dark' = 'dark'
+const LIGHT: 'light' = 'light'
+
+type InitialTheme = typeof DARK | typeof LIGHT | undefined
+
+const themes = {
+  light: { primaryLight: '#FFFFFF', primaryDark: '#000000' },
+  dark: { primaryLight: '#000000', primaryDark: '#FFFFFF' }
+}
+
+const ThemesContext = createContext(themes)
+
+const useTheme = (initialTheme: InitialTheme = DARK) => {
+  const themes = useContext(ThemesContext)
+  const [theme, setTheme] = useState(initialTheme)
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light')
+  }
+  return useMemo(() => ({ ...themes[theme], toggleTheme }), [theme])
+}
+
+type InitialProps = { initialTheme: InitialTheme }
+
+function checkTypesWithNoInitialProps() {
+  const { result, unmount, rerender } = renderHook(() => useTheme())
+
+  // check types
+  const _result: {
+    current: {
+      primaryDark: string
+      primaryLight: string
+      toggleTheme: () => void
+    }
+  } = result
+  const _unmount: () => boolean = unmount
+  const _rerender: () => void = rerender
+}
+
+function checkTypesWithInitialProps() {
+  const { result, unmount, rerender } = renderHook(
+    ({ initialTheme }: InitialProps) => useTheme(initialTheme),
+    {
+      initialProps: { initialTheme: DARK }
+    }
+  )
+
+  // check types
+  const _result: {
+    current: {
+      primaryDark: string
+      primaryLight: string
+      toggleTheme: () => void
+    }
+  } = result
+  const _unmount: () => boolean = unmount
+  const _rerender: (_: InitialProps) => void = rerender
+}

--- a/test/typescript/renderHook.ts
+++ b/test/typescript/renderHook.ts
@@ -22,8 +22,6 @@ const useTheme = (initialTheme: InitialTheme = DARK) => {
   return useMemo(() => ({ ...themes[theme], toggleTheme }), [theme])
 }
 
-type InitialProps = { initialTheme: InitialTheme }
-
 function checkTypesWithNoInitialProps() {
   const { result, unmount, rerender } = renderHook(() => useTheme())
 
@@ -40,12 +38,9 @@ function checkTypesWithNoInitialProps() {
 }
 
 function checkTypesWithInitialProps() {
-  const { result, unmount, rerender } = renderHook(
-    ({ initialTheme }: InitialProps) => useTheme(initialTheme),
-    {
-      initialProps: { initialTheme: DARK }
-    }
-  )
+  const { result, unmount, rerender } = renderHook(({ theme }) => useTheme(theme), {
+    initialProps: { theme: DARK }
+  })
 
   // check types
   const _result: {
@@ -56,5 +51,5 @@ function checkTypesWithInitialProps() {
     }
   } = result
   const _unmount: () => boolean = unmount
-  const _rerender: (_: InitialProps) => void = rerender
+  const _rerender: (_?: { theme: typeof DARK }) => void = rerender
 }

--- a/test/typescript/renderHook.ts
+++ b/test/typescript/renderHook.ts
@@ -1,36 +1,36 @@
-import { useState, createContext, useContext, useMemo } from 'react'
+import { useState, useCallback } from 'react'
 import { renderHook } from 'react-hooks-testing-library'
 
-const DARK: 'dark' = 'dark'
-const LIGHT: 'light' = 'light'
-
-type InitialTheme = typeof DARK | typeof LIGHT | undefined
-
-const themes = {
-  light: { primaryLight: '#FFFFFF', primaryDark: '#000000' },
-  dark: { primaryLight: '#000000', primaryDark: '#FFFFFF' }
-}
-
-const ThemesContext = createContext(themes)
-
-const useTheme = (initialTheme: InitialTheme = DARK) => {
-  const themes = useContext(ThemesContext)
-  const [theme, setTheme] = useState(initialTheme)
-  const toggleTheme = () => {
-    setTheme(theme === 'light' ? 'dark' : 'light')
+const useCounter = (initialCount: number = 0) => {
+  const [count, setCount] = useState(initialCount)
+  const incrementBy = useCallback(
+    (n: number) => {
+      setCount(count + n)
+    },
+    [count]
+  )
+  const decrementBy = useCallback(
+    (n: number) => {
+      setCount(count - n)
+    },
+    [count]
+  )
+  return {
+    count,
+    incrementBy,
+    decrementBy
   }
-  return useMemo(() => ({ ...themes[theme], toggleTheme }), [theme])
 }
 
 function checkTypesWithNoInitialProps() {
-  const { result, unmount, rerender } = renderHook(() => useTheme())
+  const { result, unmount, rerender } = renderHook(() => useCounter())
 
   // check types
   const _result: {
     current: {
-      primaryDark: string
-      primaryLight: string
-      toggleTheme: () => void
+      count: number
+      incrementBy: (_: number) => void
+      decrementBy: (_: number) => void
     }
   } = result
   const _unmount: () => boolean = unmount
@@ -38,18 +38,18 @@ function checkTypesWithNoInitialProps() {
 }
 
 function checkTypesWithInitialProps() {
-  const { result, unmount, rerender } = renderHook(({ theme }) => useTheme(theme), {
-    initialProps: { theme: DARK }
+  const { result, unmount, rerender } = renderHook(({ count }) => useCounter(count), {
+    initialProps: { count: 10 }
   })
 
   // check types
   const _result: {
     current: {
-      primaryDark: string
-      primaryLight: string
-      toggleTheme: () => void
+      count: number
+      incrementBy: (_: number) => void
+      decrementBy: (_: number) => void
     }
   } = result
   const _unmount: () => boolean = unmount
-  const _rerender: (_?: { theme: typeof DARK }) => void = rerender
+  const _rerender: (_?: { count: number }) => void = rerender
 }

--- a/test/typescript/renderHook.ts
+++ b/test/typescript/renderHook.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { renderHook } from 'react-hooks-testing-library'
 
 const useCounter = (initialCount: number = 0) => {
@@ -52,4 +52,15 @@ function checkTypesWithInitialProps() {
   } = result
   const _unmount: () => boolean = unmount
   const _rerender: (_?: { count: number }) => void = rerender
+}
+
+function checkTypesWhenHookReturnsVoid() {
+  const { result, unmount, rerender } = renderHook(() => useEffect(() => {}))
+
+  // check types
+  const _result: {
+    current: void
+  } = result
+  const _unmount: () => boolean = unmount
+  const _rerender: () => void = rerender
 }

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015", "dom"],
+    "strict": true,
+    "baseUrl": "../../",
+    "paths": {
+      "react-hooks-testing-library": ["index.d.ts"]
+    }
+  }
+}


### PR DESCRIPTION
Close #7 

Introduce TypeScript type definitions :tada:

- [x] Add some packages to devDependencies(`typescript`, `typings-tester`, `@types/react`)
- [x] Add `index.d.ts` to define typings
- [x] Add test for `index.d.ts` with [typings-tester](https://github.com/aikoven/typings-tester)
  - Inspired by the typing tests in [Redux repo](https://github.com/reduxjs/redux/blob/master/test/typescript.spec.js)