### PR TITLE
Add `waitForNextUpdate` promise for testing async updates

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
     "@babel/react"
   ],
   "plugins": [
+    "@babel/plugin-transform-runtime",
     "@babel/proposal-object-rest-spread",
     ["module-resolver", { "alias": { "src": "./src" } }],
     "@babel/transform-modules-commonjs"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ const useTheme = (initialTheme) => {
   }
   return useMemo(() => ({ ...themes[theme], toggleTheme }), [theme])
 }
+```
 
+```js
 // useTheme.test.js
 import { renderHook, cleanup, act } from 'react-hooks-testing-library'
 
@@ -152,6 +154,7 @@ Renders a test component that will call the provided `callback`, including any h
 
 - `result` (`object`)
   - `current` (`any`) - the return value of the `callback` function
+- `nextUpdate` (`function`) - returns a `Promise` that resolves the next time the hook renders, commonly when state is updated as the result of a asynchronous action.
 - `rerender` (`function([newProps])`) - function to rerender the test component including any hooks called in the `callback` function. If `newProps` are passed, the will replace the `initialProps` passed the the `callback` function for future renders.
 - `unmount` (`function()`) - function to unmount the test component, commonly used to trigger cleanup effects for `useEffect` hooks.
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Renders a test component that will call the provided `callback`, including any h
 
 - `result` (`object`)
   - `current` (`any`) - the return value of the `callback` function
-- `nextUpdate` (`function`) - returns a `Promise` that resolves the next time the hook renders, commonly when state is updated as the result of a asynchronous action.
+- `waitForNextUpdate` (`function`) - returns a `Promise` that resolves the next time the hook renders, commonly when state is updated as the result of a asynchronous action.
 - `rerender` (`function([newProps])`) - function to rerender the test component including any hooks called in the `callback` function. If `newProps` are passed, the will replace the `initialProps` passed the the `callback` function for future renders.
 - `unmount` (`function()`) - function to unmount the test component, commonly used to trigger cleanup effects for `useEffect` hooks.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -781,6 +781,18 @@
         "regenerator-transform": "^0.13.4"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.3.4.tgz",
+      "integrity": "sha512-PaoARuztAdd5MgeVjAxnIDAIUet5KpogqaefQvPOmPYCxYoaPhautxDh3aO8a4xHsKgT/b9gSxR0BKK1MIewPA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
@@ -904,9 +916,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
-      "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
+      "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
       "requires": {
         "regenerator-runtime": "^0.12.0"
       }
@@ -1527,25 +1539,6 @@
         "pkg-up": "^2.0.0",
         "reselect": "^3.0.1",
         "resolve": "^1.4.0"
-      }
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-          "dev": true
-        }
       }
     },
     "babel-preset-jest": {
@@ -2888,18 +2881,6 @@
         "bser": "^2.0.0"
       }
     },
-    "fetch-mock": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.3.1.tgz",
-      "integrity": "sha512-euKqWnxeApj0toZ5MSavZJ7IIxbMaHpgteV2GNuz6/slAY0JUbRe95U/ueaz2spT/4nR75H4wpEmy2MMEsCoRg==",
-      "dev": true,
-      "requires": {
-        "babel-polyfill": "^6.26.0",
-        "glob-to-regexp": "^0.4.0",
-        "path-to-regexp": "^2.2.1",
-        "whatwg-url": "^6.5.0"
-      }
-    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -3700,12 +3681,6 @@
           }
         }
       }
-    },
-    "glob-to-regexp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz",
-      "integrity": "sha512-fyPCII4vn9Gvjq2U/oDAfP433aiE64cyP/CJjRJcpVGjqqNdioUYn9+r0cSzT1XPwmGAHuTT7iv+rQT8u/YHKQ==",
-      "dev": true
     },
     "globals": {
       "version": "11.11.0",
@@ -6067,12 +6042,6 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
-      "dev": true
-    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -7135,15 +7104,6 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.3"
-      }
-    },
-    "react-async": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-async/-/react-async-5.1.0.tgz",
-      "integrity": "sha512-NrsmtBrIMcqdfTzDAhJ4wcySGTB8dHgSPfMeZWVk4NZSimjQ176tGHgjySvhijS5BjT8RykxX9hCUdIh4xhEQg==",
-      "dev": true,
-      "requires": {
-        "prop-types": ">=15.5.7"
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "contributors:add": "all-contributors add"
   },
   "dependencies": {
+    "@babel/runtime": "^7.3.4",
     "react-testing-library": "^6.0.0"
   },
   "devDependencies": {
@@ -34,6 +35,7 @@
     "@babel/core": "^7.3.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
+    "@babel/plugin-transform-runtime": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-react": "^7.0.0",
     "@types/react": "^16.8.5",
@@ -44,16 +46,13 @@
     "eslint": "^5.14.1",
     "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-prettier": "^3.0.1",
-    "fetch-mock": "^7.3.1",
     "husky": "^1.3.1",
     "jest": "^24.1.0",
     "lint-staged": "^8.1.4",
-    "node-fetch": "^2.3.0",
     "prettier": "^1.16.4",
     "prettier-eslint": "^8.8.2",
     "prettier-eslint-cli": "^4.7.1",
     "react": "^16.8.3",
-    "react-async": "^5.1.0",
     "react-dom": "^16.8.3",
     "typescript": "^3.3.3333",
     "typings-tester": "^0.3.2"

--- a/src/index.js
+++ b/src/index.js
@@ -7,11 +7,8 @@ function TestHook({ callback, hookProps, children }) {
 }
 
 function renderHook(callback, { initialProps, ...options } = {}) {
-  const result = {
-    current: null
-  }
+  const result = { current: null }
   const hookProps = { current: initialProps }
-
   const resolvers = []
   const nextUpdate = () =>
     new Promise((resolve) => {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function renderHook(callback, { initialProps, ...options } = {}) {
   const result = { current: null }
   const hookProps = { current: initialProps }
   const resolvers = []
-  const nextUpdate = () =>
+  const waitForNextUpdate = () =>
     new Promise((resolve) => {
       resolvers.push(resolve)
     })
@@ -28,7 +28,7 @@ function renderHook(callback, { initialProps, ...options } = {}) {
 
   return {
     result,
-    nextUpdate,
+    waitForNextUpdate,
     unmount,
     rerender: (newProps = hookProps.current) => {
       hookProps.current = newProps

--- a/src/index.js
+++ b/src/index.js
@@ -7,13 +7,22 @@ function TestHook({ callback, hookProps, children }) {
 }
 
 function renderHook(callback, { initialProps, ...options } = {}) {
-  const result = { current: null }
+  const result = {
+    current: null
+  }
   const hookProps = { current: initialProps }
+
+  const resolvers = []
+  const nextUpdate = () =>
+    new Promise((resolve) => {
+      resolvers.push(resolve)
+    })
 
   const toRender = () => (
     <TestHook callback={callback} hookProps={hookProps.current}>
       {(res) => {
         result.current = res
+        resolvers.splice(0, resolvers.length).forEach((resolve) => resolve())
       }}
     </TestHook>
   )
@@ -22,6 +31,7 @@ function renderHook(callback, { initialProps, ...options } = {}) {
 
   return {
     result,
+    nextUpdate,
     unmount,
     rerender: (newProps = hookProps.current) => {
       hookProps.current = newProps

--- a/test/asyncHook.test.js
+++ b/test/asyncHook.test.js
@@ -19,41 +19,41 @@ describe('async hook tests', () => {
   afterEach(cleanup)
 
   test('should wait for next update', async () => {
-    const { result, nextUpdate } = renderHook(() => useName())
+    const { result, waitForNextUpdate } = renderHook(() => useName())
 
     expect(result.current).toBe('nobody')
 
-    await nextUpdate()
+    await waitForNextUpdate()
 
     expect(result.current).toBe('Betty')
   })
 
   test('should wait for multiple updates', async () => {
-    const { result, nextUpdate, rerender } = renderHook(({ prefix }) => useName(prefix), {
+    const { result, waitForNextUpdate, rerender } = renderHook(({ prefix }) => useName(prefix), {
       initialProps: { prefix: 'Mrs.' }
     })
 
     expect(result.current).toBe('nobody')
 
-    await nextUpdate()
+    await waitForNextUpdate()
 
     expect(result.current).toBe('Mrs. Betty')
 
     rerender({ prefix: 'Ms.' })
 
-    await nextUpdate()
+    await waitForNextUpdate()
 
     expect(result.current).toBe('Ms. Betty')
   })
 
   test('should resolve all when updating', async () => {
-    const { result, nextUpdate } = renderHook(({ prefix }) => useName(prefix), {
+    const { result, waitForNextUpdate } = renderHook(({ prefix }) => useName(prefix), {
       initialProps: { prefix: 'Mrs.' }
     })
 
     expect(result.current).toBe('nobody')
 
-    await Promise.all([nextUpdate(), nextUpdate(), nextUpdate()])
+    await Promise.all([waitForNextUpdate(), waitForNextUpdate(), waitForNextUpdate()])
 
     expect(result.current).toBe('Mrs. Betty')
   })

--- a/test/asyncHook.test.js
+++ b/test/asyncHook.test.js
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react'
+import { renderHook, cleanup } from 'src'
+
+describe('async hook tests', () => {
+  const getSomeName = () => Promise.resolve('Betty')
+
+  const useName = (prefix) => {
+    const [name, setName] = useState('nobody')
+
+    useEffect(() => {
+      getSomeName().then((theName) => {
+        setName(prefix ? `${prefix} ${theName}` : theName)
+      })
+    }, [prefix])
+
+    return name
+  }
+
+  afterEach(cleanup)
+
+  test('should wait for next update', async () => {
+    const { result, nextUpdate } = renderHook(() => useName())
+
+    expect(result.current).toBe('nobody')
+
+    await nextUpdate()
+
+    expect(result.current).toBe('Betty')
+  })
+
+  test('should wait for multiple updates', async () => {
+    const { result, nextUpdate, rerender } = renderHook(({ prefix }) => useName(prefix), {
+      initialProps: { prefix: 'Mrs.' }
+    })
+
+    expect(result.current).toBe('nobody')
+
+    await nextUpdate()
+
+    expect(result.current).toBe('Mrs. Betty')
+
+    rerender({ prefix: 'Ms.' })
+
+    await nextUpdate()
+
+    expect(result.current).toBe('Ms. Betty')
+  })
+
+  test('should resolve all when updating', async () => {
+    const { result, nextUpdate } = renderHook(({ prefix }) => useName(prefix), {
+      initialProps: { prefix: 'Mrs.' }
+    })
+
+    expect(result.current).toBe('nobody')
+
+    await Promise.all([nextUpdate(), nextUpdate(), nextUpdate()])
+
+    expect(result.current).toBe('Mrs. Betty')
+  })
+})

--- a/test/typescript/renderHook.ts
+++ b/test/typescript/renderHook.ts
@@ -64,3 +64,12 @@ function checkTypesWhenHookReturnsVoid() {
   const _unmount: () => boolean = unmount
   const _rerender: () => void = rerender
 }
+
+async function checkTypesForNextUpdate() {
+  const { nextUpdate } = renderHook(() => {})
+
+  await nextUpdate()
+
+  // check type
+  const _nextUpdate: () => Promise<void> = nextUpdate
+}

--- a/test/typescript/renderHook.ts
+++ b/test/typescript/renderHook.ts
@@ -65,11 +65,11 @@ function checkTypesWhenHookReturnsVoid() {
   const _rerender: () => void = rerender
 }
 
-async function checkTypesForNextUpdate() {
-  const { nextUpdate } = renderHook(() => {})
+async function checkTypesForWaitForNextUpdate() {
+  const { waitForNextUpdate } = renderHook(() => {})
 
-  await nextUpdate()
+  await waitForNextUpdate()
 
   // check type
-  const _nextUpdate: () => Promise<void> = nextUpdate
+  const _waitForNextUpdate: () => Promise<void> = waitForNextUpdate
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,7 +9,7 @@ export function renderHook<P, R>(
   readonly result: {
     current: R
   }
-  readonly nextUpdate: () => Promise<void>
+  readonly waitForNextUpdate: () => Promise<void>
   readonly unmount: RenderResult['unmount']
   readonly rerender: (hookProps?: P) => void
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,6 +9,7 @@ export function renderHook<P, R>(
   readonly result: {
     current: R
   }
+  readonly nextUpdate: () => Promise<void>
   readonly unmount: RenderResult['unmount']
   readonly rerender: (hookProps?: P) => void
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Provide ability to wait for hook to rerender to assist in testing asynchronous hooks (e.g. react-async's `useFetch`)

**Why**:

<!-- Why are these changes necessary? -->

While asynchronous behaviour was not explicitly blocked by the library, testing it was often difficult when the internals of a hook used async patterns, but the underlying details (e.g. callback, `Promise`, etc.) were not exposed out of the hook's interface.

**How**:

<!-- How were these changes implemented? -->

The `renderHook` function now returns a `nextUpdate` function that returns a `Promise` that resolves when the hook is next rendered.  The signature and terminology is designed to work with the `async`/`await` pattern, e.g.

```js
test('something', async () => {
  const { result, nextUpdate } = renderHook(() => useFetch('/api'))

  expect(result.current.isLoading).toBe(true)

  await nextUpdate()

  expect(result.current.isLoading).toBe(false)
  expect(result.current.data).toEqual({/* ... */})
})
```

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove any items that are relevant to your changes
-->

- [x] Documentation updated
- [x] Tests
- [x] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

Before merging, I'd like some feedback on the interface, terminology and implementation of this feature.  Any feedback is welcome.

Resolves #10 