### PR TITLE
Added error handling in hook callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Renders a test component that will call the provided `callback`, including any h
 
 - `result` (`object`)
   - `current` (`any`) - the return value of the `callback` function
+  - `error` (`Error`) - the error that was thrown if the `callback` function threw an error during rendering
 - `waitForNextUpdate` (`function`) - returns a `Promise` that resolves the next time the hook renders, commonly when state is updated as the result of a asynchronous action.
 - `rerender` (`function([newProps])`) - function to rerender the test component including any hooks called in the `callback` function. If `newProps` are passed, the will replace the `initialProps` passed the the `callback` function for future renders.
 - `unmount` (`function()`) - function to unmount the test component, commonly used to trigger cleanup effects for `useEffect` hooks.

--- a/test/errorHook.test.js
+++ b/test/errorHook.test.js
@@ -1,0 +1,108 @@
+import { useState, useEffect } from 'react'
+import { renderHook } from 'src'
+
+describe('error hook tests', () => {
+  function useError(throwError) {
+    if (throwError) {
+      throw new Error('expected')
+    }
+    return true
+  }
+
+  const somePromise = () => Promise.resolve()
+
+  function useAsyncError(throwError) {
+    const [value, setValue] = useState()
+    useEffect(() => {
+      somePromise().then(() => {
+        setValue(throwError)
+      })
+    }, [throwError])
+    return useError(value)
+  }
+
+  describe('synchronous', () => {
+    test('should raise error', () => {
+      const { result } = renderHook(() => useError(true))
+
+      expect(() => {
+        expect(result.current).not.toBe(undefined)
+      }).toThrow(Error('expected'))
+    })
+
+    test('should capture error', () => {
+      const { result } = renderHook(() => useError(true))
+
+      expect(result.error).toEqual(Error('expected'))
+    })
+
+    test('should not capture error', () => {
+      const { result } = renderHook(() => useError(false))
+
+      expect(result.current).not.toBe(undefined)
+      expect(result.error).toBe(undefined)
+    })
+
+    test('should reset error', () => {
+      const { result, rerender } = renderHook((throwError) => useError(throwError), {
+        initialProps: true
+      })
+
+      expect(result.error).not.toBe(undefined)
+
+      rerender(false)
+
+      expect(result.current).not.toBe(undefined)
+      expect(result.error).toBe(undefined)
+    })
+  })
+
+  describe('asynchronous', () => {
+    test('should raise async error', async () => {
+      const { result, waitForNextUpdate } = renderHook(() => useAsyncError(true))
+
+      await waitForNextUpdate()
+
+      expect(() => {
+        expect(result.current).not.toBe(undefined)
+      }).toThrow(Error('expected'))
+    })
+
+    test('should capture async error', async () => {
+      const { result, waitForNextUpdate } = renderHook(() => useAsyncError(true))
+
+      await waitForNextUpdate()
+
+      expect(result.error).toEqual(Error('expected'))
+    })
+
+    test('should not capture async error', async () => {
+      const { result, waitForNextUpdate } = renderHook(() => useAsyncError(false))
+
+      await waitForNextUpdate()
+
+      expect(result.current).not.toBe(undefined)
+      expect(result.error).toBe(undefined)
+    })
+
+    test('should reset async error', async () => {
+      const { result, waitForNextUpdate, rerender } = renderHook(
+        (throwError) => useAsyncError(throwError),
+        {
+          initialProps: true
+        }
+      )
+
+      await waitForNextUpdate()
+
+      expect(result.error).not.toBe(undefined)
+
+      rerender(false)
+
+      await waitForNextUpdate()
+
+      expect(result.current).not.toBe(undefined)
+      expect(result.error).toBe(undefined)
+    })
+  })
+})

--- a/test/typescript/renderHook.ts
+++ b/test/typescript/renderHook.ts
@@ -65,6 +65,15 @@ function checkTypesWhenHookReturnsVoid() {
   const _rerender: () => void = rerender
 }
 
+function checkTypesWithError() {
+  const { result } = renderHook(() => useCounter())
+
+  // check types
+  const _result: {
+    error: Error
+  } = result
+}
+
 async function checkTypesForWaitForNextUpdate() {
   const { waitForNextUpdate } = renderHook(() => {})
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7,7 +7,8 @@ export function renderHook<P, R>(
   } & RenderOptions
 ): {
   readonly result: {
-    current: R
+    readonly current: R,
+    readonly error: Error
   }
   readonly waitForNextUpdate: () => Promise<void>
   readonly unmount: RenderResult['unmount']


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Capture errors that are thrown by hooks so they can be asserted in tests and are more visible in test failures.

**Why**:

<!-- Why are these changes necessary? -->

Resolves #20 

**How**:

<!-- How were these changes implemented? -->

- Added `result.error` that returns any thrown value from the hook callback
- Changed `result.current` to be getter that can throw `result.error` if value is not valid
  - Happy side-effect is that `result.current` is no `readonly` and cannot be overridden by users

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove any items that are relevant to your changes
-->

- [x] Documentation updated
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

I'll comment the parts I'm not sure about for review.
